### PR TITLE
feat: add inline edit functionality with save and cancel for products

### DIFF
--- a/src/components/ProductList.jsx
+++ b/src/components/ProductList.jsx
@@ -9,6 +9,8 @@ const ProductList = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [sortOrder, setSortOrder] = useState("asc");
   const [productList, setProductList] = useState([]);
+  const [editingProductId, setEditingProductId] = useState(null);
+  const [editForm, setEditForm] = useState({name: '', price: '', stock: ''});
 
   useEffect(() => {
     if (products) {
@@ -23,7 +25,6 @@ const ProductList = () => {
     }
   };
 
-
   const filteredProducts = useMemo(() => {
     if (!productList) return [];
     return productList.filter((product) =>
@@ -36,6 +37,51 @@ const ProductList = () => {
       sortOrder === "asc" ? a.price - b.price : b.price - a.price
     );
   }, [filteredProducts, sortOrder]);
+
+  const startEditing = (product) => {
+    setEditingProductId(product.id);
+    setEditForm({
+      name: product.name,
+      price: product.price,
+      stock: product.stock
+    })
+  }
+
+  const handleEditChange = (e) => {
+    const {name, value} = e.target;
+
+    setEditForm((prev) => ({
+      ...prev,
+      [name]: value,
+    }))
+  }
+
+  const saveEdit = (id) => {
+    if(!editForm.name || !editForm.price || !editForm.stock){
+      alert("Please fill in all fields.");
+      return;
+    }
+
+    setProductList((prev) => 
+      prev.map((product) => 
+        product.id === id 
+          ? {
+            ...product, 
+            name: editForm.name,
+            price: Number(editForm.price),
+            stock: Number(editForm.stock),
+          } 
+          : product
+      )
+    );
+    setEditingProductId(null);
+    setEditForm({name: "", price: "", stock: ""})
+  }
+
+  const cancelEdit = () => {
+    setEditingProductId(null);
+    setEditForm({ name: "", price: "", stock: ""});
+  }
 
   if (loading) {
     return <div style={{ padding: "20px", textAlign: "center" }}>Loading products...</div>;
@@ -80,20 +126,84 @@ const ProductList = () => {
         <tbody>
           {sortedProducts.length > 0 ? (
             sortedProducts.map((product) => (
-              <tr key={product.id}>
-                <td>{product.name}</td>
-                <td>{product.price}</td>
-                <td>{product.stock}</td>
+              <tr key={product.id}> 
                 <td>
-                  <button onClick={() => handleDelete(product.id)}>
-                    Delete
-                  </button>
+                {editingProductId === product.id ? ( 
+                  <input
+                    type='text'
+                    name='name'
+                    value={editForm.name}
+                    onChange={handleEditChange}
+                    className={common.formInput}
+                  />
+                ): (
+                  product.name
+                  )} 
+                </td>
+                <td>
+                  {editingProductId === product.id ? (
+                    <input
+                      type='number'
+                      name='price'
+                      value={editForm.price}
+                      onChange={handleEditChange}
+                      className={common.formInput}
+                    />
+                  ):(
+                    product.price
+                  )}
+                </td>
+                <td>
+                  {editingProductId === product.id ? (
+                    <input
+                      type='number'
+                      name='stock'
+                      value={editForm.stock}
+                      onChange={handleEditChange}
+                      className={common.formInput}
+                    />
+                  ):(
+                    product.stock
+                  )}
+                </td>
+                <td>
+                  {editingProductId === product.id ? (
+                    <>
+                    <button
+                      className={`${common.primaryButton}`}
+                      onClick={() => saveEdit(product.id)}
+                    >
+                      Save
+                    </button>
+                    <button 
+                      onClick={cancelEdit}
+                      className={`${common.primaryButton}`}
+                    >
+                      Cancel
+                    </button>
+                    </>
+                  ) : (
+                  <>
+                    <button
+                      className={`${common.primaryButton}`}
+                      onClick={() => startEditing(product)}
+                    >
+                      Edit
+                    </button>
+                    <button onClick={() => handleDelete(product.id)}
+                      className={`${common.primaryButton}`}
+                    >
+                      Delete
+                    </button>
+                  </>
+                  )}
+                  
                 </td>
               </tr>
             ))
           ) : (
             <tr>
-              <td colSpan="3" style={{ textAlign: "center" }}>
+              <td colSpan="4" style={{ textAlign: "center" }}>
                 No products found.
               </td>
             </tr>

--- a/src/styles/common.module.css
+++ b/src/styles/common.module.css
@@ -18,17 +18,27 @@
   .primaryButton {
     font-weight: bold;
     padding: 10px 20px;
-    background-color: var(--color-primary-bg);;
+    background-color: var(--color-primary-bg);
     color: var(--color-text-light);
     border: none;
     border-radius: var(--radius);
     font-size: var(--font-size);
     cursor: pointer;
     transition: background-color 0.2s ease;
+    margin-right: 8px;
+    margin-bottom: 8px;
+  }
+
+  /* Remove margin on last button in a row */
+  .primaryButton:last-child {
+    margin-right: 0px;
+    margin-bottom: 0px;
   }
   
   .primaryButton:hover {
     background-color: var(--color-hover-bg);
+    color: var(--color-primary-bg);
+    border: 2px solid var(--color-primary-bg);
   }
   /* Section Heading */
   .heading {


### PR DESCRIPTION
### Summary

This PR adds inline editing capabilities to the product list. Users can now click the **Edit** button to update a product's `name`, `price`, or `stock`. The changes can be saved or canceled inline.

### Features Added

- Inline form inputs for editing product fields
- Save button to persist changes in UI
- Cancel button to discard changes
- State management for edit mode (`editingProductId`, `editForm`)
- Minor bug fix: corrected `colSpan` in empty state row
- Converted input strings to numbers for `price` and `stock` when saving

### How to Test

1. Run the app.
2. Click "Edit" next to a product.
3. Modify the `name`, `price`, or `stock` fields.
4. Click "Save" to apply changes.
5. Click "Cancel" to discard.

Closes #28 
